### PR TITLE
use stdpath('data') instead of stdpath('config')

### DIFF
--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---@class PersistenceOptions
 local defaults = {
-  dir = vim.fn.expand(vim.fn.stdpath("cache") .. "/sessions/"), -- directory where session files are saved
+  dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/"), -- directory where session files are saved
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
 }
 

--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---@class PersistenceOptions
 local defaults = {
-  dir = vim.fn.expand(vim.fn.stdpath("config") .. "/sessions/"), -- directory where session files are saved
+  dir = vim.fn.expand(vim.fn.stdpath("cache") .. "/sessions/"), -- directory where session files are saved
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
 }
 


### PR DESCRIPTION
i feel like session files don't belong in the neovim config dir by default