### PR TITLE
Enable sessions per git branch and set global variable if running

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - automatically saves the active session under `.config/nvim/sessions` on exit
 - simple API to restore the current or last session
+- make use of sessions per git branch
 
 ## ⚡️ Requirements
 
@@ -51,6 +52,7 @@ Persistence comes with the following defaults:
 ```lua
 {
   dir = vim.fn.expand(vim.fn.stdpath("config") .. "/sessions/"), -- directory where session files are saved
+  use_git_branch = false, -- create session files based on the branch of the git enabled repository
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# 💾 Persistence
+# 💾 Persisted
 
-**Persistence** is a simple lua plugin for automated session management.
+**Persisted** is a simple lua plugin for automated session management within Neovim.
+
+The plugin was forked from the fantastic [Persistence.nvim](https://github.com/folke/persistence.nvim) as active development had paused.
 
 ## ✨ Features
 
-- automatically saves the active session under `.config/nvim/sessions` on exit
-- simple API to restore the current or last session
-- make use of sessions per git branch
+- Automatically saves the active session under `.config/nvim/sessions` on exit
+- Simple API to restore the current or last session
+- Make use of sessions per git branch
 
 ## ⚡️ Requirements
 
@@ -21,11 +23,11 @@ Install the plugin with your preferred package manager:
 ```lua
 -- Lua
 use({
-  "folke/persistence.nvim",
+  "olimorris/persisted.nvim",
   event = "BufReadPre", -- this will only start session saving when an actual file was opened
-  module = "persistence",
+  module = "persisted",
   config = function()
-    require("persistence").setup()
+    require("persisted").setup()
   end,
 })
 ```
@@ -34,10 +36,10 @@ use({
 
 ```vim
 " Vim Script
-Plug 'folke/persistence.nvim'
+Plug 'olimorris/persisted.nvim'
 
 lua << EOF
-  require("persistence").setup {
+  require("persisted").setup {
     -- your configuration comes here
     -- or leave it empty to use the default settings
     -- refer to the configuration section below
@@ -47,7 +49,7 @@ EOF
 
 ## ⚙️ Configuration
 
-Persistence comes with the following defaults:
+Persisted comes with the following defaults:
 
 ```lua
 {
@@ -59,16 +61,16 @@ Persistence comes with the following defaults:
 
 ## 🚀 Usage
 
-**Persistence** works well with plugins like `startify` or `dashboard`. It will never restore a session automatically,
+**Persisted** works well with plugins like `startify` or `dashboard`. It will never restore a session automatically,
 but you can of course write an autocmd that does exactly that if you want.
 
 ```lua
 -- restore the session for the current directory
-vim.api.nvim_set_keymap("n", "<leader>qs", [[<cmd>lua require("persistence").load()<cr>]])
+vim.api.nvim_set_keymap("n", "<leader>qs", [[<cmd>lua require("persisted").load()<cr>]])
 
 -- restore the last session
-vim.api.nvim_set_keymap("n", "<leader>ql", [[<cmd>lua require("persistence").load({ last = true })<cr>]])
+vim.api.nvim_set_keymap("n", "<leader>ql", [[<cmd>lua require("persisted").load({ last = true })<cr>]])
 
 -- stop Persistence => session won't be saved on exit
-vim.api.nvim_set_keymap("n", "<leader>qd", [[<cmd>lua require("persistence").stop()<cr>]])
+vim.api.nvim_set_keymap("n", "<leader>qd", [[<cmd>lua require("persisted").stop()<cr>]])
 ```

--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -3,6 +3,7 @@ local M = {}
 ---@class PersistenceOptions
 local defaults = {
   dir = vim.fn.expand(vim.fn.stdpath("config") .. "/sessions/"), -- directory where session files are saved
+  use_git_branch = false, -- create session files based on the branch of the git enabled repository
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
 }
 

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -6,7 +6,21 @@ local e = vim.fn.fnameescape
 
 function M.get_current()
   local name = vim.fn.getcwd():gsub("/", "%%")
-  return Config.options.dir .. name .. ".vim"
+  return Config.options.dir .. name .. M.get_branch() ..".vim"
+end
+
+function M.get_branch()
+  if Config.options.use_git_branch == true then
+    local branch = vim.api.nvim_exec([[!git rev-parse --abbrev-ref HEAD]], true)
+    -- The command returns two lines. We only need the second one
+    lines = {}
+    for s in branch:gmatch("[^\r\n]+") do
+      table.insert(lines, '_' .. s)
+    end
+    return lines[2]:gsub("/", "%%")
+  end
+
+  return ''
 end
 
 function M.get_last()
@@ -33,8 +47,8 @@ end
 
 function M.stop()
   vim.cmd([[
-  autocmd! Persistence
-  augroup! Persistence
+    autocmd! Persistence
+    augroup! Persistence
   ]])
 end
 

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -46,6 +46,7 @@ function M.start()
 end
 
 function M.stop()
+  vim.g.using_persistance = nil
   vim.cmd([[
     autocmd! Persistence
     augroup! Persistence
@@ -57,12 +58,14 @@ function M.save()
   vim.o.sessionoptions = table.concat(Config.options.options, ",")
   vim.cmd("mks! " .. e(M.get_current()))
   vim.o.sessionoptions = tmp
+  vim.g.using_persistance = e(M.get_current())
 end
 
 function M.load(opt)
   opt = opt or {}
   local sfile = opt.last and M.get_last() or M.get_current()
   if sfile and vim.fn.filereadable(sfile) ~= 0 then
+    vim.g.using_persistance = e(sfile)
     vim.cmd("source " .. e(sfile))
   end
 end

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -10,7 +10,7 @@ function M.get_current()
     pattern = '[\\:]'
   end
   local name = vim.fn.getcwd():gsub(pattern, "%%")
-  return Config.options.dir .. name .. ".vim"
+  return Config.options.dir .. name .. M.get_branch() .. ".vim"
 end
 
 function M.get_branch()

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -16,7 +16,7 @@ end
 function M.get_branch()
   local git_enabled = (vim.fn.isdirectory(vim.fn.getcwd()..'/.git') == 1)
 
-  if Config.options.use_git_branch == true and git_enabled == true then
+  if Config.options.use_git_branch and git_enabled then
     local branch = vim.api.nvim_exec([[!git rev-parse --abbrev-ref HEAD 2>/dev/null]], true)
 
     -- The branch command returns two lines. We only need the second line

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -46,7 +46,7 @@ function M.start()
 end
 
 function M.stop()
-  vim.g.using_persistance = nil
+  vim.g.using_persistence = nil
   vim.cmd([[
     autocmd! Persistence
     augroup! Persistence
@@ -58,14 +58,14 @@ function M.save()
   vim.o.sessionoptions = table.concat(Config.options.options, ",")
   vim.cmd("mks! " .. e(M.get_current()))
   vim.o.sessionoptions = tmp
-  vim.g.using_persistance = e(M.get_current())
+  vim.g.using_persistence = e(M.get_current())
 end
 
 function M.load(opt)
   opt = opt or {}
   local sfile = opt.last and M.get_last() or M.get_current()
   if sfile and vim.fn.filereadable(sfile) ~= 0 then
-    vim.g.using_persistance = e(sfile)
+    vim.g.using_persistence = e(sfile)
     vim.cmd("source " .. e(sfile))
   end
 end

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -43,14 +43,15 @@ function M.start()
       autocmd VimLeavePre * lua require("persistence").save()
     augroup end
   ]])
+  vim.g.using_persistence = true
 end
 
 function M.stop()
-  vim.g.using_persistence = nil
   vim.cmd([[
     autocmd! Persistence
     augroup! Persistence
   ]])
+  vim.g.using_persistence = false
 end
 
 function M.save()
@@ -58,15 +59,15 @@ function M.save()
   vim.o.sessionoptions = table.concat(Config.options.options, ",")
   vim.cmd("mks! " .. e(M.get_current()))
   vim.o.sessionoptions = tmp
-  vim.g.using_persistence = e(M.get_current())
+  vim.g.using_persistence = true
 end
 
 function M.load(opt)
   opt = opt or {}
   local sfile = opt.last and M.get_last() or M.get_current()
   if sfile and vim.fn.filereadable(sfile) ~= 0 then
-    vim.g.using_persistence = e(sfile)
     vim.cmd("source " .. e(sfile))
+    vim.g.using_persistence = true
   end
 end
 

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -10,10 +10,13 @@ function M.get_current()
 end
 
 function M.get_branch()
-  if Config.options.use_git_branch == true then
-    local branch = vim.api.nvim_exec([[!git rev-parse --abbrev-ref HEAD]], true)
-    -- The command returns two lines. We only need the second one
-    lines = {}
+  local git_enabled = (vim.fn.isdirectory(vim.fn.getcwd()..'/.git') == 1)
+
+  if Config.options.use_git_branch == true and git_enabled == true then
+    local branch = vim.api.nvim_exec([[!git rev-parse --abbrev-ref HEAD 2>/dev/null]], true)
+
+    -- The branch command returns two lines. We only need the second line
+    local lines = {}
     for s in branch:gmatch("[^\r\n]+") do
       table.insert(lines, '_' .. s)
     end

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -6,7 +6,7 @@ local e = vim.fn.fnameescape
 
 function M.get_current()
   local pattern = "/"
-  if vim.fn.has("win32") then
+  if vim.fn.has("win32") == 1 then
     pattern = '[\\:]'
   end
   local name = vim.fn.getcwd():gsub(pattern, "%%")


### PR DESCRIPTION
Firstly, thank you for writing such a beautifully simple Lua based session management plugin. I had previously used Vim-Obsession coupled with Vim-Prosession. Your plugin did _nearly_ everything I needed it to do.

## My workflow
Before I explain this pull request I'd like to explain how I work and hence why I made the changes.

I often work across two projects at any one time. However, within those projects are many git branches that I switch between. We implement git-flow rather religiously so  I may be viewing the _develop_ branch and then switching to a _hotfix_ or a brand new _feature_. As such, it's really handy to quickly switch branch on the command line and recover exactly where I was last time from within Neovim.

Lastly, I like to know if Persistence is running or not. So I display a small glyph in my statusline to indicate its status. That way I know whether I need to initiate or stop it.

## The proposed changes

### Git branching
Enabling of an option called `use_git_branch` to enable session files to be created for the cwd and the current git branch. The main change has been the addition of a function called `get_branch()` which determines the current branch. I opted to run a vim command for this as it is cleaner than some of the pure Lua alternatives I saw.

If enabled, then session files will be saved like:

```bash
%Users%Oli%Code%Projects%persistence_feature%add-git-branch-to-session.vim
```

where `_feature%add-git-branch-to-session` is the branch `feature\add-git-branch-to-session`.

If `use_git_branch` is enabled and the cwd is not a git enabled repo, then `_HEAD.vim` is appended to the session filename. I detect this by looking for a `.git` folder within the cwd.

### Determine if Persistence is running
I added a global variable `using_persistence` to the `start`, `save`, `load`, and `stop` commands. If active then `true` is returned. If Persistence has been stopped then a `false` is returned. This makes it easy to check for Persistence's status using a `vim.g.using_persistence` command from within my statusline config.

It allows me to have a really useful helper function in my dotfiles for loading/starting/stopping sessions:

```lua
function manage_sessions()
  if vim.g.using_persistence == nil then
    return vim.cmd('lua require("persistence").load()')
  end
  if vim.g.using_persistence then
    return vim.cmd('lua require("persistence").stop()')
  end
  return vim.cmd('lua require("persistence").start()')
end
map('n', '<Leader>s', '<cmd>call v:lua.manage_sessions()<CR>', opts)
```

## Summary
Hopefully some simple changes that don't change the beautiful simplicity of this plugin. I also hope they're useful features for the rest of the community. I feel other session plugins are far too bloated, complicated and still lacking the features I need.