### PR TITLE
feat(persistence): `pre_save` option to call before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Persistence comes with the following defaults:
 {
   dir = vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/"), -- directory where session files are saved
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
+  pre_save = nil, -- a function to call before saving the session
 }
 ```
 

--- a/doc/persistence.nvim.txt
+++ b/doc/persistence.nvim.txt
@@ -71,6 +71,7 @@ Persistence comes with the following defaults:
     {
       dir = vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/"), -- directory where session files are saved
       options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
+      pre_save = nil, -- a function to call before saving the session
     }
 <
 

--- a/doc/persistence.txt
+++ b/doc/persistence.txt
@@ -71,6 +71,7 @@ Persistence comes with the following defaults:
     {
       dir = vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/"), -- directory where session files are saved
       options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
+      pre_save = nil, -- a function to call before saving the session
     }
 <
 

--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 ---@class PersistenceOptions
+---@field pre_save? fun()
 local defaults = {
   dir = vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/"), -- directory where session files are saved
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -30,6 +30,10 @@ function M.start()
   vim.api.nvim_create_autocmd("VimLeavePre", {
     group = vim.api.nvim_create_augroup("persistence", { clear = true }),
     callback = function()
+      if Config.options.pre_save then
+        Config.options.pre_save()
+      end
+
       M.save()
     end,
   })


### PR DESCRIPTION
## About

This PR adds the `pre_save` option, which is a `fun()|nil` that will be called (if present) before saving the current session. 

Use cases include filtering buffers, executing autocmds, etc. Example config using lazy.nvim, for integration with [barbar.nvim](https://github.com/romgrk/barbar.nvim):

```lua
{'folke/persistence.nvim', opts = {
  options = {'buffers', 'curdir', 'globals', 'tabpages', 'winsize'},
  pre_save = function() vim.api.nvim_exec_autocmds('User', {pattern = 'SessionSavePre'}) end,
}},
```

## Motivation

[barbar.nvim](https://github.com/romgrk/barbar.nvim)'s is a `&tabline` plugin which has builtin integration with session files. Our implementation differs from [bufferline.nvim](https://github.com/akinsho/bufferline.nvim)'s in that we do not keep a global variable synced with the state of the plugin, until it comes time to export it to a session. 

Normally, it is advised to create a wrapper function around the `:mksession` (or plugin equivalent) command which runs `:doautocmd` with our `User` event pattern. However, this plugin (extremely conveniently) saves sessions without requiring user intervention. Thus, in order to ensure that our event runs first, a user of our plugin would have to clear the `persistence` augroup and recreate it, adding only one function call.

That solution seemed a bit hacky to me, so I wanted to see if creating a `pre_save` option would be a viable alternative. This implementation allows not just integration with barbar.nvim and user configurations, but it also allows new plugins to wait to sync global variables relevant to a session until necessary, which increases performance.

---

Feel free to request that the variable name or implementation details be changed. Also feel free to close the PR if this isn't something that aligns with the goals of the plugin.