### PR TITLE
Allow session management to have a delayed start.

### DIFF
--- a/doc/persistence.nvim.txt
+++ b/doc/persistence.nvim.txt
@@ -55,6 +55,7 @@ Persistence comes with the following defaults:
       dir = vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/"), -- directory where session files are saved
       options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
       pre_save = nil, -- a function to call before saving the session
+      auto_start = true -- manage sessions at startup, or defer until manually started
     }
 <
 

--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -5,6 +5,7 @@ local M = {}
 local defaults = {
   dir = vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/"), -- directory where session files are saved
   options = { "buffers", "curdir", "tabpages", "winsize" }, -- sessionoptions used for saving
+  auto_start = true
 }
 
 ---@type PersistenceOptions

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -62,7 +62,7 @@ function M.load(opt)
   local sfile = opt.last and M.get_last() or M.get_current()
   if sfile and vim.fn.filereadable(sfile) ~= 0 then
     vim.cmd("silent! source " .. e(sfile))
-    M.running = true
+    if not M.running then M.start() end
   end
 end
 

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -21,9 +21,14 @@ function M.get_last()
   return sessions[1]
 end
 
+function M.config()
+  return Config.options
+end
+
 function M.setup(opts)
+  M.running = false
   Config.setup(opts)
-  M.start()
+  if opts.auto_start then M.start() end
 end
 
 function M.start()
@@ -37,10 +42,12 @@ function M.start()
       M.save()
     end,
   })
+  M.running = true
 end
 
 function M.stop()
   pcall(vim.api.nvim_del_augroup_by_name, "persistence")
+  M.running = false
 end
 
 function M.save()
@@ -55,6 +62,7 @@ function M.load(opt)
   local sfile = opt.last and M.get_last() or M.get_current()
   if sfile and vim.fn.filereadable(sfile) ~= 0 then
     vim.cmd("silent! source " .. e(sfile))
+    M.running = true
   end
 end
 

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -21,8 +21,8 @@ function M.get_last()
   return sessions[1]
 end
 
-function M.config()
-  return Config.options
+function M.has_session()
+  return vim.fn.filereadable( M.get_current() ) == 1
 end
 
 function M.setup(opts)


### PR DESCRIPTION
I'm really enjoying the simplicity of persistence, but coming from Obsession, there's a few things I was wanting, and I think this patch addresses them all.

- I use nvim for all sorts of sysadmin stuff, I don't need session files getting littered around unless I'm actually in a project that warrants it -- I want control over when to start and stop the management
- I'd like to have a way to ask the plugin if it's currently active or not (a cleaner way might be to just check for the existence of the 'persistence' augroup, but I didn't find any methods to do that.)
- Similarly, I'd like to ask the plugin if a session file is present for some basic boolean stuff.

With this patch, I can integrate things with lualine,

```lua
local function sessionRunning()
	if require( 'persistence' ).running then
		return ''
	else
		return ''
	end
end
```

... dashboard,

```lua
shortcut = {
	{
		desc = '↪️ Restore Session ',
		action = function()
			persistence = require( 'persistence' )
			if persistence.has_session() then
				persistence.load()
			else
				print "No session for this directory."
			end
		end,
		key = 's',
	},
```

and have a global "on/off" switch for only starting up a session when *I* want:

```lua
require( 'persistence' ).setup({
	auto_start = false
})

-- Toggle session tracking for current directory.
--
vim.keymap.set( '', '<F8>', function()
	local persistence = require( 'persistence' )
	if persistence.running then
		persistence.stop()
		print "Disabled session tracking."
	else
		persistence.start()
		print "Enabled session tracking."
	end
end, { desc = "Toggle session tracking" })
```

This also indirectly fixes stuff like #14 as a possible alternative option.

Default behavior is exactly as-is, this shouldn't change anything for existing installations.
