### PR TITLE
Add a `session_available` method to check if session file exists

### DIFF
--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -4,6 +4,10 @@ local M = {}
 
 local e = vim.fn.fnameescape
 
+function M.session_available()
+  return vim.fn.filereadable(M.get_current()) == 1
+end
+
 function M.get_current()
   local pattern = "/"
   if vim.fn.has("win32") == 1 then


### PR DESCRIPTION
Hi, just set up persistence.nvim and really liking it so far. I thought it'd be nice to add a quick "restore session" button on my dashboard, and conditionally only show that button when a session exists for the current working directory.

Unsure if I should've written a short example on the README/docs so users would find it easier.

EDIT: I'm so sorry, I just read #30 also adds this feature. I hadn't looked beyond the PR titles. Should I just close this one?