### PR TITLE
fix: don't save `gitrebase` session

### DIFF
--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -45,6 +45,9 @@ function M.start()
           if vim.bo[b].filetype == "gitcommit" then
             return false
           end
+          if vim.bo[b].filetype == "gitrebase" then
+            return false
+          end
           return vim.api.nvim_buf_get_name(b) ~= ""
         end, vim.api.nvim_list_bufs())
         if #bufs == 0 then


### PR DESCRIPTION
Skip saving the session if it contains a `gitrebase` buffer. Similar to https://github.com/folke/persistence.nvim/commit/8f7cbccfb506fe6cb35db9ad966137c363b049c5.

Steps to reproduce:
1. Set nvim as `$EDITOR`.
2. run `git rebase --interactive` and close nvim
3. re-open nvim and notice how the gitrebase buffer is opened