### PR TITLE
Trigger SessionLoadPost upon load()

### DIFF
--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -77,6 +77,9 @@ function M.load(opt)
   local sfile = opt.last and M.get_last() or M.get_current()
   if sfile and vim.fn.filereadable(sfile) ~= 0 then
     vim.cmd("silent! source " .. e(sfile))
+    vim.defer_fn(function()
+      vim.cmd("doautocmd SessionLoadPost")
+    end, 100)
   end
 end
 


### PR DESCRIPTION
For example, this enables bufferline ordering persistence, which relies on the `SessionLoadPost` `autocmd`, ref https://github.com/akinsho/bufferline.nvim/blob/b15c6daf5a64426c69732b31a951f4e438cb6590/lua/bufferline.lua#L116

In my testing, it was necessary to wrap it in `defer_fn`, but I don't actually know why.

Not to be confused with persisting *pinned* buffers, which seems to be available since
https://github.com/LazyVim/LazyVim/pull/304/files