### PR TITLE
fix(list): support eXtra session files

### DIFF
--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -92,7 +92,17 @@ end
 
 ---@return string[]
 function M.list()
-  local sessions = vim.fn.glob(Config.options.dir .. "*.vim", true, true)
+  local all_sessions = vim.fn.glob(Config.options.dir .. "*.vim", true, true)
+  local sessions = vim.tbl_filter(function(file)
+    local filename = vim.fn.fnamemodify(file, ":t")
+    if filename:match("x.vim$") then
+      local base_session = file:sub(1, -5) .. ".vim"
+      if vim.fn.filereadable(base_session) == 1 then
+        return false
+      end
+    end
+    return true
+  end, all_sessions)
   table.sort(sessions, function(a, b)
     return uv.fs_stat(a).mtime.sec > uv.fs_stat(b).mtime.sec
   end)


### PR DESCRIPTION
From `:help mksession`, number 10:

> 10. If a file exists with the same name as the Session file, but ending in
>   "x.vim" (for eXtra), executes that as well.  You can use `*x.vim` files to
>   specify additional settings and actions associated with a given Session,
>   such as creating menu items in the GUI version.

I use tabs as "projects" - each tab has it's  own directory (`:tcd`), and a name (so my tabs display the actual name of the project, which is done with `let t:layout_name = 'foo'`), it looks like this:

![CleanShot 2025-02-04 at 10 30
59](https://github.com/user-attachments/assets/3209198a-2fda-40bb-8055-8c5dc1e58e39)

Those types of variables are not saved in a regular session, so I have to use the `eXtra` option, something like this:

```lua
vim.api.nvim_create_autocmd("User", {
  pattern = "PersistenceSavePost",
  group = session_save_group,
  callback = function()
    local persistence = require("persistence")
    local current = persistence.current()
    local filename = vim.fn.fnamemodify(current, ":t:r")
    local extension = vim.fn.fnamemodify(current, ":e")
    local session_dir = vim.fn.stdpath("state") .. "/sessions"
    local x = session_dir .. "/" .. filename .. "x." .. extension
    local lines = {}

    local tabpages = vim.api.nvim_list_tabpages()
    local current_nr = vim.api.nvim_get_current_tabpage()

    for _, nr in ipairs(tabpages) do
      vim.api.nvim_set_current_tabpage(nr)
      table.insert(lines, "tabnext " .. nr)

      local has_tcd = vim.fn.haslocaldir(-1, vim.api.nvim_tabpage_get_number(nr))
      if has_tcd == 1 then
        local tcd = vim.fn.getcwd(-1, vim.api.nvim_tabpage_get_number(nr))
        table.insert(lines, "tcd " .. tcd)
      end

      local project_dir = vim.t.project_dir

      if project_dir ~= nil then
        table.insert(lines, 'let t:project_dir = "' .. project_dir .. '"')
      end

      local layout_name = vim.t.layout_name
      if layout_name ~= nil then
        table.insert(lines, 'let t:layout_name = "' .. layout_name .. '"')
      end
    end

    table.insert(lines, "tabnext " .. current_nr)
    table.insert(lines, "redrawtabline")

    vim.fn.writefile(lines, x)
  end,
})
```

Only issue is that persistence.nvim lists the `*x.vim` files as other sessions, and when loading "last", it always loads only the eXtra file (which basically does nothing, since it depends on the real session file) since it was written last.

This makes the list function ignore `*x.vim` files, but only if there's an associated file with the same name without the `x` before the extension (this way hopefully it doesn't erroneously ignore a session that just happens to have an `x` at the end of the name).

