### PR TITLE
fix(start): don't count ft=jj buffers for persistence

### DIFF
--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -45,7 +45,7 @@ function M.start()
 
       if Config.options.need > 0 then
         local bufs = vim.tbl_filter(function(b)
-          if vim.bo[b].buftype ~= "" or vim.bo[b].filetype == "gitcommit" or vim.bo[b].filetype == "gitrebase" then
+          if vim.bo[b].buftype ~= "" or vim.bo[b].filetype == "gitcommit" or vim.bo[b].filetype == "gitrebase" or vim.bo[b].filetype == "jj" then
             return false
           end
           return vim.api.nvim_buf_get_name(b) ~= ""


### PR DESCRIPTION
## Description

Don't count `ft=jj` buffers towards those that need persisting

## Related Issue(s)

https://github.com/LazyVim/LazyVim/discussions/5545

