### PR TITLE
feat(main): skip on args

### DIFF
--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -7,7 +7,7 @@ local defaults = {
   -- Set to 0 to always save
   need = 1,
   branch = true, -- use git branch to save session
-  skip_on_args = true, -- skip saving session if arguments are passed
+  skip_on_args = false, -- skip saving session if arguments are passed
 }
 
 ---@type Persistence.Config

--- a/lua/persistence/config.lua
+++ b/lua/persistence/config.lua
@@ -7,6 +7,7 @@ local defaults = {
   -- Set to 0 to always save
   need = 1,
   branch = true, -- use git branch to save session
+  skip_on_args = true, -- skip saving session if arguments are passed
 }
 
 ---@type Persistence.Config

--- a/lua/persistence/init.lua
+++ b/lua/persistence/init.lua
@@ -55,6 +55,15 @@ function M.start()
         end
       end
 
+      if Config.options.skip_on_args then
+        local args = vim.fn.argv()
+        if type(args) == "table" and next(args) ~= nil then
+          return
+        elseif type(args) == "string" and args ~= "" then
+          return
+        end
+      end
+
       M.save()
       M.fire("SavePost")
     end,


### PR DESCRIPTION
## Description

This PR adds an option to skip saving the session in case neovim was started with file arguments. This is very helpful in case you're starting neovim to quickly edit a file in a directory that has a session saved to it without losing your previously saved session.
